### PR TITLE
aes_128.v: Add `rst` signal to S4_0

### DIFF
--- a/generators/mitll-blocks/src/main/resources/vsrc/aes/aes_128.v
+++ b/generators/mitll-blocks/src/main/resources/vsrc/aes/aes_128.v
@@ -120,7 +120,7 @@ begin
 end
 
 S4
-    S4_0 (clk, {k3[23:0], k3[31:24]}, k4a);
+    S4_0 (clk, rst, {k3[23:0], k3[31:24]}, k4a);
 
 assign k0b = k0a ^ k4a;
 assign k1b = k1a ^ k4a;
@@ -133,7 +133,7 @@ begin
 	    out_1 <= 0;
 	else
 	    out_1 <= {k0b, k1b, k2b, k3b};
-end		
+end
 assign out_2 = {k0b, k1b, k2b, k3b};
 endmodule
 


### PR DESCRIPTION
Hello!

In testing out the AES Engine you have, I noticed that I never got a valid out. In digging in, I found that there was no reset signal on S4_0 (as shown by the commit). After adding that, the AES Engine can as expected. If you want to validate, I used this testbench. The Key, Ciphertext, and plaintext come from: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38a.pdf For verification.

```
`timescale 1ns/1ps

module tb_aes_128();
  parameter MAX_CYCLES = 1000;
  logic  [32*8-1:0] vcd_output_filename = "./top_test.vcd";

  logic         clk;        // Set by testbench
  logic         rst;        // Set by testbench
  logic         start;      // Set by testbench
  logic [127:0] state;      // Set by testbench, block input
  logic [127:0] key;        // Set by testbench
  logic [127:0] out;        // Output from DUT
  logic         out_valid;  // Output from DUT

  // FPGA/Scan Clock generation, 100 MHz
  initial
    clk=1'b1;
  always begin
    #1
    clk=~clk;
  end

  // Circuit Reset (for 2 clock cycles)
  initial begin
    rst = 1;
    #37
    rst = 0;
  end

  // Count the number of clock cycles since reset
  logic [31:0] counter;
  always @(posedge clk) begin
    if(rst)
      counter <= 32'b0;
    else
      counter <= counter + 1;
  end

  // Hard timeout after MAX_CYCLES
  always @(posedge clk) begin
    if(counter > MAX_CYCLES) begin
      $display("INFO: Testbench Hit Max Cycles...");
      $finish();
    end
  end

  // Dump output to VCD
  initial begin
    if ($test$plusargs("DUMP_FILE")) begin
      void'($value$plusargs ("DUMP_FILE=%s", vcd_output_filename));
    end
    $display("\tDUMP_FILE:\t%s", vcd_output_filename);
    $dumpfile(vcd_output_filename);
    $dumpvars(0, tb_aes_128);
  end

	aes_128 dut (
		.clk(clk),
        .rst(rst),
        .start(start),
		.state(state),
		.key(key),
		.out(out),
		.out_valid(out_valid)
	);

	initial begin
		clk = 0;
		state = 0;
		start = 0;
		key = 0;
		#40;
        @ (negedge clk);
        #2;
        start = 1;
        state = 128'h6bc1bee22e409f96e93d7e117393172a;
        key   = 128'h2b7e151628aed2a6abf7158809cf4f3c;
        #170;
        if (out !== 128'h3ad77bb40d7a3660a89ecaf32466ef97)
          begin $display("E"); $finish; end
        #10;
        #100;
        $finish;
	end

endmodule : tb_sbox
```